### PR TITLE
Migrate Aura Contracts and Update bb-a-usd

### DIFF
--- a/_setup/StrategyResolver.py
+++ b/_setup/StrategyResolver.py
@@ -68,7 +68,7 @@ class StrategyResolver(StrategyCoreResolver):
         # bbaUsd is autocompounded when strategy balance is greater than minBbaUsdHarvest
         # Find amount of bb-a-usd harvested
         amount = 0
-        rewardsPool = "0xFD176Ba656b91F0cE8C59ad5C3245beBb99cd69a"
+        rewardsPool = "0x62D7d772b2d909A0779d15299F4FC87e34513c6d"
         for transfer in tx.events["Transfer"]:
             if transfer["from"] == rewardsPool and transfer["to"] == self.manager.strategy:
                 amount = transfer["value"]
@@ -76,7 +76,6 @@ class StrategyResolver(StrategyCoreResolver):
 
         total_bb_a_usd = amount + before.balances("bbaUsd", "strategy")
         threshold = self.manager.strategy.minBbaUsdHarvest()
-
         if total_bb_a_usd < threshold:
             assert (
                 after.balances("bbaUsd", "strategy") == total_bb_a_usd

--- a/contracts/AuraBalStakerStrategy.sol
+++ b/contracts/AuraBalStakerStrategy.sol
@@ -45,9 +45,9 @@ contract AuraBalStakerStrategy is BaseStrategy {
     IERC20Upgradeable public constant BALETH_BPT =
         IERC20Upgradeable(0x5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56);
     IERC20Upgradeable public constant BB_A_USD =
-        IERC20Upgradeable(0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2);
+        IERC20Upgradeable(0xA13a9247ea42D743238089903570127DdA72fE44);
     IERC20Upgradeable public constant BB_A_USDC =
-        IERC20Upgradeable(0x9210F1204b5a24742Eba12f710636D76240dF3d0);
+        IERC20Upgradeable(0x82698aeCc9E28e9Bb27608Bd52cF57f704BD1B83);
     IERC20Upgradeable public constant USDC =
         IERC20Upgradeable(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
 
@@ -56,9 +56,9 @@ contract AuraBalStakerStrategy is BaseStrategy {
     bytes32 public constant AURABAL_BALETH_BPT_POOL_ID =
         0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249;
     bytes32 public constant BB_A_USD_POOL_ID =
-        0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe;
+        0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d;
     bytes32 public constant BB_A_USDC_POOL_ID =
-        0x9210f1204b5a24742eba12f710636d76240df3d00000000000000000000000fc;
+        0x82698aecc9e28e9bb27608bd52cf57f704bd1b83000000000000000000000336;
     bytes32 public constant USDC_WETH_POOL_ID =
         0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019;
 

--- a/contracts/AuraBalStakerStrategy.sol
+++ b/contracts/AuraBalStakerStrategy.sol
@@ -25,7 +25,7 @@ contract AuraBalStakerStrategy is BaseStrategy {
     uint256 public minBbaUsdHarvest;
 
     IBaseRewardPool public constant AURABAL_REWARDS =
-        IBaseRewardPool(0x5e5ea2048475854a5702F5B8468A51Ba1296EFcC);
+        IBaseRewardPool(0x00A7BA8Ae7bca0B10A32Ea1f8e2a1Da980c6CAd2);
 
     IVault public constant GRAVIAURA =
         IVault(0xBA485b556399123261a5F9c95d413B4f93107407);

--- a/tests/upgrade/test_migrate.py
+++ b/tests/upgrade/test_migrate.py
@@ -1,10 +1,20 @@
 import brownie
 import pytest
 
-from brownie import *
+from brownie import (
+    AuraBalStakerStrategy,
+    TheVault,
+    AdminUpgradeabilityProxy,
+    interface,
+    accounts,
+    chain
+)
 
 from helpers.constants import AddressZero
 from helpers.time import days
+from rich.console import Console
+
+C = Console()
 
 
 VAULT_ADDRESS = "0x37d9D2C6035b744849C15F1BFEE8F268a20fCBd8"
@@ -14,14 +24,24 @@ VAULT_ADDRESS = "0x37d9D2C6035b744849C15F1BFEE8F268a20fCBd8"
 def vault_proxy():
     return TheVault.at(VAULT_ADDRESS)
 
+@pytest.fixture
+def gov(vault_proxy):
+    return accounts.at(vault_proxy.governance(), force=True)
 
 @pytest.fixture
-def strat_proxy(vault_proxy):
-    return AuraBalStakerStrategy.at(vault_proxy.strategy())
-
+def strat_proxy(vault_proxy, gov):
+    return AuraBalStakerStrategy.at(vault_proxy.strategy(), owner=gov)
 
 @pytest.fixture
-def new_strategy(vault_proxy, proxyAdmin, deployer):
+def current_bb_a_usd(strat_proxy):
+    return interface.ERC20(strat_proxy.BB_A_USD())
+
+@pytest.fixture
+def want(strat_proxy):
+    return interface.ERC20(strat_proxy.want())
+
+@pytest.fixture
+def new_strategy(vault_proxy, proxyAdmin, deployer, gov):
     args = [vault_proxy]
 
     strat_logic = AuraBalStakerStrategy.deploy({"from": deployer})
@@ -34,16 +54,32 @@ def new_strategy(vault_proxy, proxyAdmin, deployer):
 
     ## We delete from deploy and then fetch again so we can interact
     AdminUpgradeabilityProxy.remove(strat_proxy)
-    strat_proxy = AuraBalStakerStrategy.at(strat_proxy.address)
-
-    return strat_proxy
+    return AuraBalStakerStrategy.at(strat_proxy.address, owner=gov)
 
 
-def test_check_storage_integrity(strat_proxy, vault_proxy, new_strategy):
-    with brownie.reverts():
-        strat_proxy.minBbaUsdHarvest()
+@pytest.fixture
+def new_bb_a_usd(new_strategy):
+    return interface.ERC20(new_strategy.BB_A_USD())
 
-    ## Check Integrity
+
+
+def test_migrate(strat_proxy, vault_proxy, new_strategy, current_bb_a_usd, new_bb_a_usd, gov, want):
+    ## 1. Reduce "minBbaUsdHarvest" threshold on old strategy and Harvest
+    current_bbausd_bal = current_bb_a_usd.balanceOf(strat_proxy)
+    strat_proxy.setMinBbaUsdHarvest(current_bbausd_bal - 1)
+    strat_proxy.harvest()
+    assert current_bb_a_usd.balanceOf(strat_proxy) == 0
+
+
+    ##. 2. Sweep new bb_a_USD from old strat
+    new_bbausd_bal_gov = new_bb_a_usd.balanceOf(gov)
+    new_bbausd_bal = new_bb_a_usd.balanceOf(strat_proxy)
+    vault_proxy.sweepExtraToken(new_bb_a_usd.address, {"from": gov})
+    assert new_bb_a_usd.balanceOf(gov) == new_bbausd_bal_gov + new_bbausd_bal
+
+
+    ## 3. Migrate strategies
+    # Check Integrity
     assert new_strategy.want() == strat_proxy.want()
     assert new_strategy.vault() == strat_proxy.vault()
     assert (
@@ -61,35 +97,36 @@ def test_check_storage_integrity(strat_proxy, vault_proxy, new_strategy):
     )
 
     # Check if var exists
-    assert new_strategy.BB_A_USD() != AddressZero
+    assert new_strategy.BB_A_USD() != strat_proxy.BB_A_USD()
     assert new_strategy.minBbaUsdHarvest() == int(1000e18)
-
-    gov = accounts.at(vault_proxy.governance(), force=True)
-    bb_a_usd = interface.IERC20(strat_proxy.BB_A_USD())
-
-    # Harvest
-    strat_proxy.harvest({"from": gov})
+    # Check that threshold is lower than current bb_a_usd balance
+    assert new_strategy.minBbaUsdHarvest() < new_bbausd_bal
 
     # Checkpoint balance
-    old_balance = vault_proxy.balance()
+    balance = vault_proxy.balance()
+    balance_of_pool = strat_proxy.balanceOfPool()
+    vault_balance = want.balanceOf(vault_proxy)
+    assert balance == balance_of_pool + vault_balance
 
     # Migrate strategy
     vault_proxy.withdrawToVault({"from": gov})
 
     assert strat_proxy.balanceOf() == 0
-
     vault_proxy.setStrategy(new_strategy, {"from": gov})
     assert vault_proxy.strategy() == new_strategy
 
     vault_proxy.earn({"from": gov})
 
     assert new_strategy.balanceOf() > 0
-    assert vault_proxy.balance() == old_balance
+    assert vault_proxy.balance() == balance
 
     # Sleep to accrue rewards
-    chain.sleep(days(2))
+    chain.sleep(days(3))
     chain.mine()
 
-    # Test harvest
-    new_strategy.harvest({"from": gov})
-    assert bb_a_usd.balanceOf(new_strategy) > 0
+
+    # 4. Send new bb_a_usd o strat and harvest
+    new_bb_a_usd.transfer(new_strategy, new_bbausd_bal, {"from": gov})
+    assert new_bb_a_usd.balanceOf(new_strategy) == new_bbausd_bal
+    new_strategy.harvest()
+    assert new_bb_a_usd.balanceOf(new_strategy) == 0


### PR DESCRIPTION
Relates to https://github.com/Badger-Finance/badger-strategies/issues/85
Tackles https://github.com/Badger-Finance/Badger-Project-Planning/issues/110

### Changes Introduces
- Updated the cvxCrvRewards contract according to Aura's internal migration
- Updated the bb_a_USD reward and swap path to the new version of the pool
- Adapted the migration test to successfully process the old bb-a-usd, sweep the new one from the old strat, migrate, transfer the new bb-a-usd to the strat and harvest to process it.
- Adapted the rest of the tests as needed

![image](https://user-images.githubusercontent.com/25463788/208174077-087fa554-5996-4a8d-a5c9-33000d2fcbe2.png)

The `test_expected_aura_rewards_match_minted` fails as well here (same as for the rest of the aura strategies). @shuklaayush and I have already looked into this in the past and we haven't been able to figure out why is this. I will take a look again but I don't think it should be a blocker.